### PR TITLE
Add python support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "py3findimagedupes"]
+	path = py3findimagedupes
+	url = https://github.com/JolonB/py3findimagedupes.git

--- a/DeleteVisuallyRedundant.py
+++ b/DeleteVisuallyRedundant.py
@@ -49,7 +49,6 @@ def delete_all_but_original(filepaths:List, dry_run:bool=False):
         filepaths (List): A list of paths to the files.
         dry_run (bool, optional): Only print filenames without deleting. Defaults to False.
     """
-    # TODO add comments!!
     def delete_file(filepath:str):
         """Print the name of the given file and delete it if dry_run is False.
 
@@ -95,6 +94,13 @@ def delete_all_but_original(filepaths:List, dry_run:bool=False):
 
 
 def main(directory:str, keep_temp_file:bool=False, dry_run:bool=False):
+    """Find all duplicate files in the provided directory. Delete any duplicate files.
+
+    Args:
+        directory (str): The directory to look within.
+        keep_temp_file (bool, optional): Keep the temporary file generated when finding duplicates. Defaults to False.
+        dry_run (bool, optional): Don't delete any files. Only report files that would be deleted. Defaults to False.
+    """
     find_duplicates(directory)
     with open(DUPLICATES_FILE, "r") as fp:
         for line in fp:

--- a/DeleteVisuallyRedundant.py
+++ b/DeleteVisuallyRedundant.py
@@ -10,7 +10,7 @@ try:
     from pyfindimagedupes import pyfindimagedupes
 
     USE_PYTHON = True
-except ModuleNotFoundError:
+except (ModuleNotFoundError, ImportError):
     USE_PYTHON = False
 
 DUPLICATES_FILE = "dups.txt"

--- a/DeleteVisuallyRedundant.py
+++ b/DeleteVisuallyRedundant.py
@@ -33,49 +33,43 @@ def find_duplicates(filepath):
 
 def delete_all_but_original(filepaths, dry_run=False):
     # TODO add comments!!
-    max_size = 0
-    max_filepaths = []
-    remaining_filepaths = []
+    def delete_file(filepath):
+        print("D: {}".format(filepath))
+        if not dry_run:
+            os.remove(filepath)
 
-    # TODO tidy all of this up
-    for filepath in filepaths:
-        size = os.stat(filepath).st_size
-        if size > max_size:
-            max_size = size
+    # Keep track of any files that weren't deleted
+    largest_files = []
+    remaining_files = []
 
+    # Find the size of the largest file
+    max_size = max(os.stat(filepath).st_size for filepath in filepaths)
+    # Delete any files that are smaller
     for filepath in filepaths:
         size = os.stat(filepath).st_size
 
         if size < max_size:
-            print("D:", filepath)
-            if not dry_run:
-                os.remove(filepath)
+            delete_file(filepath)
         elif size == max_size:
-            max_filepaths.append(filepath)
+            largest_files.append(filepath)
 
-    if len(max_filepaths) > 1:
-        oldest_modified_time = float("inf")
-
-        for filepath in max_filepaths:
-            modified_time = os.stat(filepath).st_mtime
-
-            if modified_time < oldest_modified_time:
-                oldest_modified_time = modified_time
-
-        for filepath in max_filepaths:
+    if len(largest_files) > 1:
+        # Get the earliest modified file
+        oldest_modified_time = min(
+            os.stat(filepath).st_mtime for filepath in largest_files
+        )
+        # Delete any files that are more recent
+        for filepath in largest_files:
             modified_time = os.stat(filepath).st_mtime
 
             if modified_time > oldest_modified_time:
-                print("D:", filepath)
-                if not dry_run:
-                    os.remove(filepath)
+                delete_file(filepath)
             elif modified_time == oldest_modified_time:
-                remaining_filepaths.append(filepath)
+                remaining_files.append(filepath)
 
-    # Remove all but one duplicate if any still exist
-    for filepath in remaining_filepaths[1:]:
-        if not dry_run:
-            os.remove(filepath)
+        # Remove all but one duplicate if any still exist
+        for filepath in remaining_files[1:]:
+            delete_file(filepath)
 
 
 def main(filepath, keep_temp_file=False, dry_run=False):

--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ These are the accepted options:
 Dependencies
 ------------
 
-* [findimagedupes](https://github.com/jhnc/findimagedupes) - May be available in a package manager
+* [`findimagedupes`](https://github.com/jhnc/findimagedupes) - May be available in a package manager
+
+**or**
+
+* `py3findimagedupes` - Available through `git submodule init; git submodule update`
+  * This depends on `pgmagick`. Instructions are available in the `py3findimagedupes` README.
 
 Gotchas
 -------


### PR DESCRIPTION
Add support for Python, rather than requiring `findimagedupes` which may not be as available on different operating systems.
The Python support does require pgmagick, so it is ultimately up to the user which version they use. The Python version will automatically run if the user has cloned the submodule.